### PR TITLE
Consolidate odoo settings into one URL

### DIFF
--- a/common_flags.go
+++ b/common_flags.go
@@ -5,21 +5,6 @@ import "github.com/urfave/cli/v2"
 const defaultTextForRequiredFlags = "<required>"
 
 func newOdooURLFlag(destination *string) *cli.StringFlag {
-	return &cli.StringFlag{Name: "odoo-url", Usage: "Odoo ERP URL in the form of https://host/",
+	return &cli.StringFlag{Name: "odoo-url", Usage: "Odoo ERP URL in the form of https://username:password@host[:port]/db-name",
 		EnvVars: envVars("ODOO_URL"), Destination: destination, Required: true, DefaultText: defaultTextForRequiredFlags}
-}
-
-func newOdooDBFlag(destination *string) *cli.StringFlag {
-	return &cli.StringFlag{Name: "odoo-db", Usage: "Odoo Database name",
-		EnvVars: envVars("ODOO_DB"), Destination: destination, Required: true, DefaultText: defaultTextForRequiredFlags}
-}
-
-func newOdooUsernameFlag(destination *string) *cli.StringFlag {
-	return &cli.StringFlag{Name: "odoo-username", Usage: "Odoo ERP username for authentication",
-		EnvVars: envVars("ODOO_USERNAME"), Destination: destination, Required: true, DefaultText: defaultTextForRequiredFlags}
-}
-
-func newOdooPasswordFlag(destination *string) *cli.StringFlag {
-	return &cli.StringFlag{Name: "odoo-password", Usage: "Odoo ERP password for authentication",
-		EnvVars: envVars("ODOO_PASSWORD"), Destination: destination, Required: true, DefaultText: defaultTextForRequiredFlags}
 }

--- a/odoo/client_test.go
+++ b/odoo/client_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -17,6 +18,48 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 )
+
+func TestNewClient(t *testing.T) {
+	tests := map[string]struct {
+		givenURL         string
+		expectedPassword string
+		expectedUsername string
+		expectedDBName   string
+		expectedError    string
+	}{
+		"GivenURLWithoutUserInfo_ThenExpectError": {
+			givenURL:      "https://host:80/db",
+			expectedError: "missing username and password in URL",
+		},
+		"GivenURLWithoutPassword_ThenExpectError": {
+			givenURL:      "https://user@host:80/db",
+			expectedError: "missing password in URL",
+		},
+		"GivenURLWithoutDB_ThenExpectError": {
+			givenURL:      "https://user:pass@host:80/",
+			expectedError: "missing db name in URL path",
+		},
+		"GivenValidURL_ThenExpectParsedProperties": {
+			givenURL:         "https://user:pass@host:80/db-name",
+			expectedUsername: "user",
+			expectedPassword: "pass",
+			expectedDBName:   "db-name",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c, err := NewClient(tc.givenURL)
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDBName, c.db)
+			assert.Equal(t, tc.expectedUsername, c.username)
+			assert.Equal(t, tc.expectedPassword, c.password)
+		})
+	}
+}
 
 func TestClient_Login_Success(t *testing.T) {
 	var (
@@ -60,10 +103,10 @@ func TestClient_Login_Success(t *testing.T) {
 	defer odooMock.Close()
 
 	// Login
-	client, err := NewClient(odooMock.URL, "TestDB")
+	client, err := NewClient(newTestURL(t, odooMock.URL, testLogin, testPassword, "TestDB"))
 	require.NoError(t, err)
 	client.UseDebugLogger(true)
-	session, err := client.Login(newTestContext(t), testLogin, testPassword)
+	session, err := client.Login(newTestContext(t))
 	require.NoError(t, err)
 	assert.Equal(t, testUID, session.UID)
 	assert.Equal(t, testSID, session.SessionID)
@@ -99,10 +142,10 @@ func TestLogin_BadCredentials(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(odooMock.URL, "TestDB")
+	client, err := NewClient(newTestURL(t, odooMock.URL, testLogin, testPassword, "TestDB"))
 	require.NoError(t, err)
 	client.UseDebugLogger(true)
-	session, err := client.Login(newTestContext(t), testLogin, testPassword)
+	session, err := client.Login(newTestContext(t))
 	require.EqualError(t, err, "invalid credentials")
 	assert.Nil(t, session)
 	assert.Equal(t, 1, numRequests)
@@ -133,10 +176,10 @@ func TestLogin_BadResponse(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(odooMock.URL, "TestDB")
+	client, err := NewClient(newTestURL(t, odooMock.URL, "irrelevant", "irrelevant", "TestDB"))
 	require.NoError(t, err)
 	client.UseDebugLogger(true)
-	session, err := client.Login(newTestContext(t), "", "")
+	session, err := client.Login(newTestContext(t))
 	require.EqualError(t, err, "error from Odoo: &{Odoo Server Error 200 map[arguments:[] debug:Traceback xxx message: name:werkzeug.exceptions.Foo]}")
 	assert.Nil(t, session)
 	assert.Equal(t, 1, numRequests)
@@ -145,4 +188,13 @@ func TestLogin_BadResponse(t *testing.T) {
 func newTestContext(t *testing.T) context.Context {
 	zlogger := zaptest.NewLogger(t, zaptest.Level(zapcore.Level(-2)))
 	return logr.NewContext(context.Background(), zapr.NewLogger(zlogger))
+}
+
+func newTestURL(t *testing.T, baseURL, username, password, db string) string {
+	parsed, err := url.Parse(baseURL)
+	require.NoError(t, err)
+	user := url.UserPassword(username, password)
+	parsed.User = user
+	parsed.Path = db
+	return parsed.String()
 }

--- a/odoo/debug.go
+++ b/odoo/debug.go
@@ -21,13 +21,7 @@ func newDebugTransport() *debugTransport {
 	}
 }
 
-// UseDebugLogger sets the http.Transport field of the internal http client with a transport implementation that logs the raw contents of requests and responses.
-// The logger is retrieved from the request's context via logr.FromContextOrDiscard.
-// The log level used is '2'.
-// Any "password":"..." byte content is replaced with a placeholder to avoid leaking credentials.
-// Still, this should not be called in production as other sensitive information might be leaked.
-// This method is meant to be called before any requests are made (for example after setting up the Client).
-func (c Client) UseDebugLogger(enabled bool) {
+func (c Client) useDebugLogger(enabled bool) {
 	if enabled {
 		c.http.Transport = newDebugTransport()
 	}

--- a/odoo/session_test.go
+++ b/odoo/session_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,10 +46,10 @@ func TestSession_CreateGenericModel(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(newTestURL(t, odooMock.URL, "irrelevant", "irrelevant", "TestDB"))
+	u, err := url.Parse(odooMock.URL)
 	require.NoError(t, err)
-	client.UseDebugLogger(true)
-	session := Session{client: client}
+	session := Session{client: &Client{http: http.DefaultClient, parsedURL: u}}
+	session.client.http.Transport = newDebugTransport()
 	result, err := session.CreateGenericModel(newTestContext(t), "model", "data")
 	require.NoError(t, err)
 	assert.Equal(t, 221, result)
@@ -91,10 +92,10 @@ func TestSession_UpdateGenericModel(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(newTestURL(t, odooMock.URL, "irrelevant", "irrelevant", "TestDB"))
+	u, err := url.Parse(odooMock.URL)
 	require.NoError(t, err)
-	client.UseDebugLogger(true)
-	session := Session{client: client}
+	session := Session{client: &Client{http: http.DefaultClient, parsedURL: u}}
+	session.client.http.Transport = newDebugTransport()
 	err = session.UpdateGenericModel(newTestContext(t), "model", 1, "data")
 	require.NoError(t, err)
 	assert.Equal(t, 1, numRequests)
@@ -133,10 +134,10 @@ func TestSession_DeleteGenericModel(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(newTestURL(t, odooMock.URL, "irrelevant", "irrelevant", "TestDB"))
+	u, err := url.Parse(odooMock.URL)
 	require.NoError(t, err)
-	client.UseDebugLogger(true)
-	session := Session{client: client}
+	session := Session{client: &Client{http: http.DefaultClient, parsedURL: u}}
+	session.client.http.Transport = newDebugTransport()
 	err = session.DeleteGenericModel(newTestContext(t), "model", []int{100})
 	require.NoError(t, err)
 	assert.Equal(t, 1, numRequests)

--- a/odoo/session_test.go
+++ b/odoo/session_test.go
@@ -45,7 +45,7 @@ func TestSession_CreateGenericModel(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(odooMock.URL, "TestDB")
+	client, err := NewClient(newTestURL(t, odooMock.URL, "irrelevant", "irrelevant", "TestDB"))
 	require.NoError(t, err)
 	client.UseDebugLogger(true)
 	session := Session{client: client}
@@ -91,7 +91,7 @@ func TestSession_UpdateGenericModel(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(odooMock.URL, "TestDB")
+	client, err := NewClient(newTestURL(t, odooMock.URL, "irrelevant", "irrelevant", "TestDB"))
 	require.NoError(t, err)
 	client.UseDebugLogger(true)
 	session := Session{client: client}
@@ -133,7 +133,7 @@ func TestSession_DeleteGenericModel(t *testing.T) {
 	defer odooMock.Close()
 
 	// Do request
-	client, err := NewClient(odooMock.URL, "TestDB")
+	client, err := NewClient(newTestURL(t, odooMock.URL, "irrelevant", "irrelevant", "TestDB"))
 	require.NoError(t, err)
 	client.UseDebugLogger(true)
 	session := Session{client: client}

--- a/sync_command.go
+++ b/sync_command.go
@@ -33,20 +33,13 @@ func (c *syncCommand) execute(context *cli.Context) error {
 	_ = LogMetadata(context)
 	log := AppLogger(context).WithName(syncCommandName)
 
-	client, err := odoo.NewClient(c.OdooURL)
-	if err != nil {
-		return err
-	}
-	client.UseDebugLogger(context.Bool("debug"))
-	log.V(1).Info("Logging in to Odoo...", "url", c.OdooURL, "db", client.DBName())
-
 	odooCtx := logr.NewContext(context.Context, log)
-
-	session, err := client.Login(odooCtx)
+	log.V(1).Info("Logging in to Odoo...")
+	session, err := odoo.Open(odooCtx, c.OdooURL, odoo.ClientOptions{UseDebugLogger: context.Bool("debug")})
 	if err != nil {
 		return err
 	}
-	log.Info("Login succeeded", "uid", session.UID)
+	log.Info("login succeeded", "uid", session.UID)
 
 	// Demo Odoo API
 	o := model.NewOdoo(session)


### PR DESCRIPTION
## Summary

* Reduces dedicated CLI flags `odoo-db`, `odoo-username`, `odoo-password` into one single flag `odoo-url`, where DB name and credentials are passed directly into the URL.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
