### PR TITLE
Prefix invoice titles with partner names from Odoo

### DIFF
--- a/invoice/invoice.go
+++ b/invoice/invoice.go
@@ -15,15 +15,19 @@ import (
 func CreateInvoice(ctx context.Context, client *model.Odoo, invoice invoice.Invoice, options ...Option) (int, error) {
 	opts := buildOptions(options)
 
-	name := fmt.Sprintf("APPUiO Cloud %s %d", invoice.PeriodStart.Month(), invoice.PeriodStart.Year())
-	toCreate := opts.invoiceDefaults
-	toCreate.Name = name
-	toCreate.Date = odoo.Date(opts.InvoiceDateOrNow())
-
 	partnerID, err := strconv.Atoi(invoice.Tenant.Target)
 	if err != nil {
 		return 0, fmt.Errorf("error converting tenant target to int: %w", err)
 	}
+	partner, err := client.FetchPartnerByID(ctx, partnerID)
+	if err != nil {
+		return 0, fmt.Errorf("error fetching partner info from Odoo: %w", err)
+	}
+
+	name := fmt.Sprintf("%s APPUiO Cloud %s %d", partner.Name, invoice.PeriodStart.Month(), invoice.PeriodStart.Year())
+	toCreate := opts.invoiceDefaults
+	toCreate.Name = name
+	toCreate.Date = odoo.Date(opts.InvoiceDateOrNow())
 	toCreate.PartnerID = partnerID
 
 	lines := make([]model.InvoiceLine, 0)

--- a/invoice/invoice.go
+++ b/invoice/invoice.go
@@ -23,6 +23,9 @@ func CreateInvoice(ctx context.Context, client *model.Odoo, invoice invoice.Invo
 	if err != nil {
 		return 0, fmt.Errorf("error fetching partner info from Odoo: %w", err)
 	}
+	if partner == nil {
+		return 0, fmt.Errorf("partner with id \"%d\" could not be found", partnerID)
+	}
 
 	name := fmt.Sprintf("%s APPUiO Cloud %s %d", partner.Name, invoice.PeriodStart.Month(), invoice.PeriodStart.Year())
 	toCreate := opts.invoiceDefaults

--- a/odoo/model/partner.go
+++ b/odoo/model/partner.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	"context"
+
+	"github.com/vshn/appuio-odoo-adapter/odoo"
+)
+
+type Partner struct {
+	ID   int    `json:"id,omitempty" yaml:"id,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type PartnerList struct {
+	Items []Partner `json:"records"`
+}
+
+// FetchPartnerByID searches for the partner by ID and returns the first entry in the result.
+// If no result has been found, nil is returned without error.
+func (o Odoo) FetchPartnerByID(ctx context.Context, id int) (*Partner, error) {
+	result, err := o.searchPartners(ctx, []odoo.Filter{
+		[]interface{}{"id", "in", []int{id}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(result) > 0 {
+		return &result[0], nil
+	}
+	// not found
+	return nil, nil
+}
+
+func (o Odoo) searchPartners(ctx context.Context, domainFilters []odoo.Filter) ([]Partner, error) {
+	result := &PartnerList{}
+	err := o.querier.SearchGenericModel(ctx, odoo.SearchReadModel{
+		Model:  "res.partner",
+		Domain: domainFilters,
+		Fields: []string{"name"},
+	}, result)
+	return result.Items, err
+}

--- a/odoo/model/partner.go
+++ b/odoo/model/partner.go
@@ -6,11 +6,15 @@ import (
 	"github.com/vshn/appuio-odoo-adapter/odoo"
 )
 
+// Partner represents a partner ("Customer") record in Odoo
 type Partner struct {
-	ID   int    `json:"id,omitempty" yaml:"id,omitempty"`
+	// ID is the data record identifier.
+	ID int `json:"id,omitempty" yaml:"id,omitempty"`
+	// Name is the display name of the partner.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
+// PartnerList holds the search results for Partner for deserialization
 type PartnerList struct {
 	Items []Partner `json:"records"`
 }


### PR DESCRIPTION
## Summary

We fetch the partner name from Odoo based on the invoice's tenant target ID and add it as a prefix to the invoice title.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
