### PR TITLE
Fetch partner payment terms and add them to generated invoice

### DIFF
--- a/invoice/invoice.go
+++ b/invoice/invoice.go
@@ -32,6 +32,7 @@ func CreateInvoice(ctx context.Context, client *model.Odoo, invoice invoice.Invo
 	toCreate.Name = name
 	toCreate.Date = odoo.Date(opts.InvoiceDateOrNow())
 	toCreate.PartnerID = partnerID
+	toCreate.PaymentTermID = partner.PaymentTerm.ID
 
 	lines := make([]model.InvoiceLine, 0)
 	for _, category := range invoice.Categories {

--- a/odoo/model/partner.go
+++ b/odoo/model/partner.go
@@ -12,6 +12,8 @@ type Partner struct {
 	ID int `json:"id,omitempty" yaml:"id,omitempty"`
 	// Name is the display name of the partner.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// PaymentTerm holds the terms of payment for the partner
+	PaymentTerm PartnerPaymentTerm `json:"property_payment_term,omitempty" yaml:"property_payment_term,omitempty"`
 }
 
 // PartnerList holds the search results for Partner for deserialization
@@ -40,7 +42,7 @@ func (o Odoo) searchPartners(ctx context.Context, domainFilters []odoo.Filter) (
 	err := o.querier.SearchGenericModel(ctx, odoo.SearchReadModel{
 		Model:  "res.partner",
 		Domain: domainFilters,
-		Fields: []string{"name"},
+		Fields: []string{"name", "property_payment_term"},
 	}, result)
 	return result.Items, err
 }

--- a/odoo/model/partner_payment_term.go
+++ b/odoo/model/partner_payment_term.go
@@ -1,0 +1,54 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// PartnerPaymentTerm represents term of payment for a partner
+type PartnerPaymentTerm struct {
+	// ID is the data record identifier for the terms of payment
+	ID int
+	// Name is a human-readable description for the terms of payment
+	Name string
+}
+
+// UnmarshalJSON handles deserialization of PartnerPaymentTerm.
+func (t *PartnerPaymentTerm) UnmarshalJSON(b []byte) error {
+	var values []interface{}
+	if err := json.Unmarshal(b, &values); err != nil {
+		return err
+	}
+
+	isFullNumber := func(n float64) bool {
+		_, frac := math.Modf(n)
+		return frac == 0
+	}
+
+	if len(values) != 2 {
+		return fmt.Errorf("expected %d elements in slice, got %d", 2, len(values))
+	}
+
+	tID, ok := values[0].(float64)
+	if !ok {
+		return fmt.Errorf("expected first value to be of type float64 (number), got %v", values[0])
+	}
+	if !isFullNumber(tID) {
+		return fmt.Errorf("expected first value to be a full number, got %E", tID)
+	}
+
+	tName, ok := values[1].(string)
+	if !ok {
+		return fmt.Errorf("expected second value to be of type string, got %v", values[1])
+	}
+
+	t.ID = int(tID)
+	t.Name = tName
+	return nil
+}
+
+// MarshalJSON handles serialization of PartnerPaymentTerm.
+func (t PartnerPaymentTerm) MarshalJSON() ([]byte, error) {
+	return json.Marshal([...]interface{}{t.ID, t.Name})
+}

--- a/odoo/model/partner_payment_term_test.go
+++ b/odoo/model/partner_payment_term_test.go
@@ -1,0 +1,42 @@
+package model_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vshn/appuio-odoo-adapter/odoo/model"
+)
+
+func TestPartnerPaymentTermMarshal(t *testing.T) {
+	subject := model.PartnerPaymentTerm{ID: 2, Name: "10 Days"}
+	marshalled, err := json.Marshal(subject)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(marshalled), fmt.Sprintf(`[%d,%q]`, subject.ID, subject.Name))
+
+	var unmarshalled model.PartnerPaymentTerm
+	require.NoError(t, json.Unmarshal(marshalled, &unmarshalled))
+	require.Equal(t, subject.ID, unmarshalled.ID)
+}
+
+func TestPartnerPaymentTermUnmarshal(t *testing.T) {
+	tests := []struct {
+		raw  string
+		errf require.ErrorAssertionFunc
+	}{
+		{`[2,"10 Days"]`, require.NoError},
+		{`[2.5,"test"]`, require.Error},
+		{`""`, require.Error},
+		{`[2,"10 Days",5]`, require.Error},
+		{`["2","10 Days"]`, require.Error},
+		{`[2,10]`, require.Error},
+	}
+
+	for _, testCase := range tests {
+		var unmarshalled model.PartnerPaymentTerm
+		err := json.Unmarshal([]byte(testCase.raw), &unmarshalled)
+		testCase.errf(t, err)
+	}
+}


### PR DESCRIPTION
We need custom marshalling and unmarshalling code for the payment terms, as Odoo represents them as an array of `[ID, "Name"]` where ID is the numerical ID and Name is the textual representation of the payment terms.

The marshalling code has been modelled after the existing code for the tax id.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
