### PR TITLE
Always parse int flags (month, year) as base 10

### DIFF
--- a/invoice_command.go
+++ b/invoice_command.go
@@ -47,9 +47,9 @@ func newinvoiceCommand() *cli.Command {
 			newDatabaseURLFlag(&command.DatabaseURL),
 
 			&cli.IntFlag{Name: "year", Usage: "Year to generate the report for.",
-				EnvVars: envVars("YEAR"), Destination: &command.Year, Required: true},
+				EnvVars: envVars("YEAR"), Destination: &command.Year, Required: true, Base: 10},
 			&cli.IntFlag{Name: "month", Usage: "Month to generate the report for.",
-				EnvVars: envVars("MONTH"), Destination: (*int)(&command.Month), Required: true},
+				EnvVars: envVars("MONTH"), Destination: (*int)(&command.Month), Required: true, Base: 10},
 			&cli.StringFlag{Name: "invoice-defaults-path", Usage: "Path to a file with invoice defaults.",
 				EnvVars: envVars("INVOICE_DEFAULTS_PATH"), Destination: &command.InvoiceDefaultsPath, Required: false},
 			&cli.StringFlag{Name: "item-description-templates-path", Usage: "Path to a directory with templates. The Files must be named `PRODUCT_SOURCE.gotmpl`.",


### PR DESCRIPTION
This allows passing months like `09`.

Fixes #57 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
- [x] Link this PR to related issues.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
